### PR TITLE
Feature/webpack dev server

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { MyComponent } from "./MyComponent";
-import { NotHMRComponent } from "./NotHMRComponent";
 
 export const App = (): JSX.Element => {
   return (
@@ -11,5 +10,3 @@ export const App = (): JSX.Element => {
     </div>
   );
 };
-
-export default App;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,4 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { App } from "./components/App";
 
-
-
 ReactDOM.render(<App />, document.getElementById("root"));

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -57,6 +57,10 @@ if (isProduction) {
   config.output.clean = true;
   config.devtool = false;
 } else {
+  // target: "browserslist" のとき、webpack-dev-server の HMRでブラウザがリロードされない。
+  // 下記issueはcloseされているが、webpack:5.47.0, webpack-dev-server:3.11.2 で再現するため、webpack-dev-server で起動する際にtargetをwebに設定する。
+  // https://github.com/webpack/webpack-dev-server/issues/2758
+  config.target = "web";
   config.mode = "development";
   config.devtool = "eval-source-map";
 }


### PR DESCRIPTION
target: "browserslist" のとき、webpack-dev-server の HMRでブラウザがリロードされない。